### PR TITLE
[#241] Add new grid keys to silence v12 warnings

### DIFF
--- a/system.json
+++ b/system.json
@@ -160,6 +160,10 @@
       "flags": {}
     }
   ],
+  "grid": {
+    "distance": 5,
+    "units": "foot"
+  },
   "gridDistance": 5,
   "gridUnits": "foot",
   "primaryTokenAttribute": "attributes.hp",
@@ -173,9 +177,9 @@
         "templates"
       ]
     },
-		"hotReload": {
-			"extensions": ["css", "hbs", "json"],
-			"paths": ["everyday-heroes.css", "templates", "lang"]
-		}
-	}
+    "hotReload": {
+      "extensions": ["css", "hbs", "json"],
+      "paths": ["everyday-heroes.css", "templates", "lang"]
+    }
+  }
 }


### PR DESCRIPTION
Fixes #241 

This adds the new grid.distance and grid.units keys too make Foundry v12 happy and silence its warnings, but keeps the previous keys to maintain v11 compatibility. When the minimum version is moved to v12 the old gridDistance and gridUnits keys can be removed.